### PR TITLE
Implement --output-profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 examples/**/backstop_data/
+node_modules

--- a/README.md
+++ b/README.md
@@ -66,4 +66,5 @@ $ backstop-retry-failed-scenarios --reference-command 'backstop reference' --com
   --config            string Path to config file. default: backstop.json
   --command           string Command to run test. default: backstop test
   --reference-command string Command to create reference before testing. Default: null (Do not create reference before test).
+  --output-profile    string Path to profiler output file. If present, measure the execution time and output the report as JSON.
 ```

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "backstop-retry-failed-scenarios",
   "version": "1.1.2",
   "description": "A wrapper command to retry failed scenario for BackstopJS",
+  "engines": {
+    "node": ">=10.18.1"
+  },
   "scripts": {
     "test": "jest",
     "test-watch": "jest --watch",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,12 @@ const optionDefinitions = [
     description:
       'Command to create reference before testing. Default: null (Do not create reference before test).',
   },
+  {
+    name: 'output-profile',
+    type: String,
+    defaultValue: null,
+    description: 'Measure the execution time and output the report as JSON.',
+  },
 ];
 const options = commandLineArgs(optionDefinitions);
 
@@ -62,6 +68,7 @@ const main = async () => {
     config: options.config,
     command: options.command,
     referenceCommand: options['reference-command'],
+    outputProfile: options['output-profile'],
   });
   await runner.run();
   process.exit(runner.exitCode);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ const optionDefinitions = [
     name: 'output-profile',
     type: String,
     defaultValue: null,
-    description: 'Measure the execution time and output the report as JSON.',
+    description: 'Path to profiler output file. If present, measure the execution time and output the report as JSON.',
   },
 ];
 const options = commandLineArgs(optionDefinitions);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,8 @@ const optionDefinitions = [
     name: 'output-profile',
     type: String,
     defaultValue: null,
-    description: 'Path to profiler output file. If present, measure the execution time and output the report as JSON.',
+    description:
+      'Path to profiler output file. If present, measure the execution time and output the report as JSON.',
   },
 ];
 const options = commandLineArgs(optionDefinitions);

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -40,7 +40,7 @@ export const Runner = class Runner {
   }
 
   async run() {
-    this.traceProfiler.start('backstop.run');
+    this.traceProfiler.start('run');
 
     this.retriedCount = 0;
     const baseCommand = this.command;
@@ -55,17 +55,17 @@ export const Runner = class Runner {
         console.log(
           `Running(${this.retriedCount}/${this.retryCount}) ${referenceCommand}`
         );
-        this.traceProfiler.start(`backstop.${this.retriedCount}.reference`);
+        this.traceProfiler.start(`${this.retriedCount}.reference`);
         await this.runOnce(referenceCommand);
-        this.traceProfiler.end(`backstop.${this.retriedCount}.reference`);
+        this.traceProfiler.end(`${this.retriedCount}.reference`);
       }
       const testCommand = `${baseCommand} ${filterOption}`;
       console.log(
         `Running(${this.retriedCount}/${this.retryCount}) ${testCommand}`
       );
-      this.traceProfiler.start(`backstop.${this.retriedCount}.test`);
+      this.traceProfiler.start(`${this.retriedCount}.test`);
       const runResult = await this.runOnce(testCommand);
-      this.traceProfiler.end(`backstop.${this.retriedCount}.test`);
+      this.traceProfiler.end(`${this.retriedCount}.test`);
       if (reports) {
         if (reports.htmlReport) {
           reports.htmlReport.notifyNewReport(config.htmlReport);
@@ -81,7 +81,7 @@ export const Runner = class Runner {
         }
       }
       if (runResult) {
-        this.traceProfiler.end('backstop.run');
+        this.traceProfiler.end('run');
         this.writeProfile();
         return true;
       }
@@ -94,7 +94,7 @@ export const Runner = class Runner {
         };
       }
     }
-    this.traceProfiler.end('backstop.run');
+    this.traceProfiler.end('run');
     this.writeProfile();
     return false;
   }

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -1,6 +1,8 @@
 import child_process from 'child_process';
+import fs from 'fs';
 
 import {Config} from './Config';
+import {TraceProfiler} from './TraceProfiler';
 
 export const Runner = class Runner {
   rootDir: string;
@@ -8,6 +10,8 @@ export const Runner = class Runner {
   configPath: string;
   command: string;
   referenceCommand?: string;
+  outputProfile?: string;
+  traceProfiler: TraceProfiler;
   retriedCount: number;
   exitCode: number;
   constructor(
@@ -17,6 +21,7 @@ export const Runner = class Runner {
       config: string;
       command: string;
       referenceCommand: string;
+      outputProfile: string;
     }>
   ) {
     this.rootDir = options.rootDir || process.cwd();
@@ -24,6 +29,8 @@ export const Runner = class Runner {
     this.configPath = options.config || 'backstop.json';
     this.command = options.command || 'backstop test';
     this.referenceCommand = options.referenceCommand;
+    this.outputProfile = options.outputProfile;
+    this.traceProfiler = new TraceProfiler();
     this.retriedCount = 0;
     this.exitCode = 1;
   }
@@ -33,6 +40,8 @@ export const Runner = class Runner {
   }
 
   async run() {
+    this.traceProfiler.start('backstop.run');
+
     this.retriedCount = 0;
     const baseCommand = this.command;
     let filterOption = '';
@@ -46,13 +55,17 @@ export const Runner = class Runner {
         console.log(
           `Running(${this.retriedCount}/${this.retryCount}) ${referenceCommand}`
         );
+        this.traceProfiler.start(`backstop.${this.retriedCount}.reference`);
         await this.runOnce(referenceCommand);
+        this.traceProfiler.end(`backstop.${this.retriedCount}.reference`);
       }
       const testCommand = `${baseCommand} ${filterOption}`;
       console.log(
         `Running(${this.retriedCount}/${this.retryCount}) ${testCommand}`
       );
+      this.traceProfiler.start(`backstop.${this.retriedCount}.test`);
       const runResult = await this.runOnce(testCommand);
+      this.traceProfiler.end(`backstop.${this.retriedCount}.test`);
       if (reports) {
         if (reports.htmlReport) {
           reports.htmlReport.notifyNewReport(config.htmlReport);
@@ -67,7 +80,11 @@ export const Runner = class Runner {
           reports.ciReport.write();
         }
       }
-      if (runResult) return true;
+      if (runResult) {
+        this.traceProfiler.end('backstop.run');
+        this.writeProfile();
+        return true;
+      }
       filterOption = `--filter '${this.filter}'`;
       if (!reports) {
         reports = {
@@ -77,6 +94,8 @@ export const Runner = class Runner {
         };
       }
     }
+    this.traceProfiler.end('backstop.run');
+    this.writeProfile();
     return false;
   }
 
@@ -105,5 +124,14 @@ export const Runner = class Runner {
 
   get filter() {
     return this.config.htmlReport.filter;
+  }
+
+  private writeProfile() {
+    if (!this.outputProfile) return;
+    const traceProfile = this.traceProfiler.generateReport();
+    fs.writeFileSync(
+      this.outputProfile,
+      JSON.stringify(traceProfile, null, '  ')
+    );
   }
 };

--- a/src/lib/TraceProfiler.ts
+++ b/src/lib/TraceProfiler.ts
@@ -1,0 +1,51 @@
+import {performance} from 'perf_hooks';
+
+type Span =
+  | {
+      startTime: number;
+    }
+  | {
+      startTime: number;
+      endTime: number;
+    };
+
+type ReportRecord = {
+  label: string;
+  duration: number;
+  startTime: number;
+  endTime: number;
+};
+type Report = ReportRecord[];
+
+export class TraceProfiler {
+  traces: Map<string, Span>;
+  constructor() {
+    this.traces = new Map();
+  }
+  start(label: string): void {
+    if (this.traces.has(label))
+      throw new Error(`'${label}' has already started tracing.`);
+    this.traces.set(label, {startTime: performance.now()});
+  }
+  end(label: string): void {
+    const span = this.traces.get(label);
+    if (span === undefined)
+      throw new Error(`'${label}' has not yet started tracing.`);
+    if ('endTime' in span)
+      throw new Error(`'${label}' has already ended tracing.`);
+    this.traces.set(label, {...span, endTime: performance.now()});
+  }
+  generateReport(): Report {
+    const report: Report = [];
+    for (const [label, span] of this.traces.entries()) {
+      if ('endTime' in span) {
+        report.push({
+          label,
+          duration: span.endTime - span.startTime,
+          ...span,
+        });
+      }
+    }
+    return report;
+  }
+}

--- a/src/test/Runner.test.ts
+++ b/src/test/Runner.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const {copy, resolve} = require('test-fixture')();
 
+import fs from 'fs';
 import {Runner} from '../lib/Runner';
 
 describe('Runner', () => {
@@ -12,6 +13,7 @@ describe('Runner', () => {
       config: 'backstop.json',
       command: 'backstop test',
       referenceCommand: 'backstop reference',
+      outputProfile: 'profile.json',
       rootDir: resolve('backstop/failed'),
     });
     expect(runner).toBeDefined();
@@ -19,6 +21,7 @@ describe('Runner', () => {
     expect(runner.configPath).toEqual('backstop.json');
     expect(runner.command).toEqual('backstop test');
     expect(runner.referenceCommand).toEqual('backstop reference');
+    expect(runner.outputProfile).toEqual('profile.json');
   });
 
   test('it parses config', async () => {
@@ -56,6 +59,52 @@ describe('Runner', () => {
       });
       expect(await runner.run()).toEqual(false);
       expect(runner.retriedCount).toEqual(3);
+    });
+
+    test('it generates output profile', async () => {
+      await copy();
+      const outputProfile = resolve('profile.json');
+      const runner = new Runner({
+        retry: 2,
+        config: 'backstop.json',
+        referenceCommand: 'not_existing_command',
+        command: 'not_existing_command',
+        outputProfile,
+        rootDir: resolve('backstop/failed'),
+      });
+      await runner.run();
+      expect(JSON.parse(fs.readFileSync(outputProfile).toString())).toEqual([
+        {
+          label: 'backstop.run',
+          duration: expect.any(Number),
+          startTime: expect.any(Number),
+          endTime: expect.any(Number),
+        },
+        {
+          label: 'backstop.1.reference',
+          duration: expect.any(Number),
+          startTime: expect.any(Number),
+          endTime: expect.any(Number),
+        },
+        {
+          label: 'backstop.1.test',
+          duration: expect.any(Number),
+          startTime: expect.any(Number),
+          endTime: expect.any(Number),
+        },
+        {
+          label: 'backstop.2.reference',
+          duration: expect.any(Number),
+          startTime: expect.any(Number),
+          endTime: expect.any(Number),
+        },
+        {
+          label: 'backstop.2.test',
+          duration: expect.any(Number),
+          startTime: expect.any(Number),
+          endTime: expect.any(Number),
+        },
+      ]);
     });
   });
 

--- a/src/test/Runner.test.ts
+++ b/src/test/Runner.test.ts
@@ -75,31 +75,31 @@ describe('Runner', () => {
       await runner.run();
       expect(JSON.parse(fs.readFileSync(outputProfile).toString())).toEqual([
         {
-          label: 'backstop.run',
+          label: 'run',
           duration: expect.any(Number),
           startTime: expect.any(Number),
           endTime: expect.any(Number),
         },
         {
-          label: 'backstop.1.reference',
+          label: '1.reference',
           duration: expect.any(Number),
           startTime: expect.any(Number),
           endTime: expect.any(Number),
         },
         {
-          label: 'backstop.1.test',
+          label: '1.test',
           duration: expect.any(Number),
           startTime: expect.any(Number),
           endTime: expect.any(Number),
         },
         {
-          label: 'backstop.2.reference',
+          label: '2.reference',
           duration: expect.any(Number),
           startTime: expect.any(Number),
           endTime: expect.any(Number),
         },
         {
-          label: 'backstop.2.test',
+          label: '2.test',
           duration: expect.any(Number),
           startTime: expect.any(Number),
           endTime: expect.any(Number),

--- a/src/test/TraceProfiler.test.ts
+++ b/src/test/TraceProfiler.test.ts
@@ -1,0 +1,93 @@
+import {TraceProfiler} from '../lib/TraceProfiler';
+import {performance} from 'perf_hooks';
+
+function mockPerformanceNow(timestamp: number, fn: () => void): void {
+  const nativePerformanceNow = performance.now;
+  performance.now = jest.fn(() => timestamp);
+  fn();
+  performance.now = nativePerformanceNow;
+}
+
+describe('TraceProfiler', () => {
+  describe('start', () => {
+    test('can be called for labels that have not yet started tracing', () => {
+      const profiler = new TraceProfiler();
+      expect(() => {
+        profiler.start('1');
+      }).not.toThrow();
+      expect(() => {
+        profiler.start('2');
+      }).not.toThrow();
+    });
+    test('cannot be called for a label that has already started tracing', () => {
+      const profiler = new TraceProfiler();
+      expect(() => {
+        profiler.start('1');
+      }).not.toThrow();
+      expect(() => {
+        profiler.start('1');
+      }).toThrowErrorMatchingInlineSnapshot(
+        // eslint-disable-next-line quotes
+        `"'1' has already started tracing."`
+      );
+    });
+  });
+
+  describe('end', () => {
+    test('can be called for a label that has already started tracing', () => {
+      const profiler = new TraceProfiler();
+      profiler.start('1');
+      expect(() => {
+        profiler.end('1');
+      }).not.toThrow();
+    });
+    test("cannot be called for a label that hasn't started tracing yet", () => {
+      const profiler = new TraceProfiler();
+      expect(() => {
+        profiler.end('1');
+      }).toThrowErrorMatchingInlineSnapshot(
+        // eslint-disable-next-line quotes
+        `"'1' has not yet started tracing."`
+      );
+    });
+    test('cannot be called for a label that has already ended tracing', () => {
+      const profiler = new TraceProfiler();
+      profiler.start('1');
+      profiler.end('1');
+      expect(() => {
+        profiler.end('1');
+      }).toThrowErrorMatchingInlineSnapshot(
+        // eslint-disable-next-line quotes
+        `"'1' has already ended tracing."`
+      );
+    });
+  });
+
+  describe('generateReport', () => {
+    test('can generate a empty report', () => {
+      const profiler = new TraceProfiler();
+      expect(profiler.generateReport()).toEqual([]);
+    });
+    test('can generate a non-empty report', () => {
+      const profiler = new TraceProfiler();
+      Date.now = jest.fn(() => 0);
+      mockPerformanceNow(0, () => profiler.start('1'));
+      mockPerformanceNow(1000, () => profiler.end('1'));
+      mockPerformanceNow(2000, () => profiler.start('2'));
+      mockPerformanceNow(3000, () => profiler.end('2'));
+      expect(profiler.generateReport()).toEqual([
+        {label: '1', duration: 1000, startTime: 0, endTime: 1000},
+        {label: '2', duration: 1000, startTime: 2000, endTime: 3000},
+      ]);
+    });
+    test('generates a report that excludes traces that have not ended', () => {
+      const profiler = new TraceProfiler();
+      mockPerformanceNow(0, () => profiler.start('1'));
+      mockPerformanceNow(1000, () => profiler.end('1'));
+      mockPerformanceNow(2000, () => profiler.start('2'));
+      expect(profiler.generateReport()).toEqual([
+        {label: '1', duration: 1000, startTime: 0, endTime: 1000},
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
I understand that this is my own idea and has not yet been endorsed by anyone. However, I think this feature is worth implementing in `backstop-retry-failed-scenarios` and decided to send a PR. If you do not need this PR, please ignore it :)

## Summary
- Enable backstop-retry-failed-scenarios to generate profiles so that backstop performance can be visualized

## Motivation
- Often backstop is very heavy and consumes a large portion of CI's processing time.
- Measuring the execution time of backstop is very important to improve the processing time of CI.
- In other words, it would be useful to have `backstop-retry-failed-scenarios` to measure the execution time of backstops.
- The purpose of this PR is to output a detailed report of how long some of the steps performed inside `backstop-retry-failed-scenarios` took.

## TODO
- [x] Implement `--output-profile`
- [x] Add test
- [ ] Add documentation
  - I'll write after the PR is accepted. 
- (If you need something else to do)
